### PR TITLE
fix: コンテキストメニューのハンドラを追加し、アイテムカードとギャラリーグリッドに対応

### DIFF
--- a/app/components/items/GalleryGrid.tsx
+++ b/app/components/items/GalleryGrid.tsx
@@ -19,6 +19,7 @@ interface GalleryGridProps {
   onTouchEnd: (e: React.TouchEvent) => void;
   onAutoScroll: (clientY: number) => void;
   onStopAutoScroll: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
 }
 
 export function GalleryGrid({
@@ -38,6 +39,7 @@ export function GalleryGrid({
   onTouchEnd,
   onAutoScroll,
   onStopAutoScroll,
+  onContextMenu,
 }: GalleryGridProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -74,7 +76,8 @@ export function GalleryGrid({
         const gridItem = elementBelow?.closest("[data-item-index]");
         if (gridItem) {
           const index = parseInt(
-            gridItem.getAttribute("data-item-index") || "0"
+            gridItem.getAttribute("data-item-index") || "0",
+            10
           );
           setDragOverIndex(index);
         }
@@ -153,6 +156,7 @@ export function GalleryGrid({
               onDragEnd={handleDragEndWithStopScroll}
               onTouchStart={onTouchStart}
               onTouchEnd={handleTouchEndWithStopScroll}
+              onContextMenu={onContextMenu}
             />
           ))}
         </div>

--- a/app/components/items/ItemCard.tsx
+++ b/app/components/items/ItemCard.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { Item } from "../../data/items";
 import { StatusBadge } from "../common/StatusBadge";
 import { getItemStatusStyles } from "../../lib/itemStyles";
-import { isUnpurchased } from "../../types/status";
 
 interface ItemCardProps {
   item: Item;
@@ -17,6 +16,7 @@ interface ItemCardProps {
   onDragEnd: (e: React.DragEvent) => void;
   onTouchStart: (e: React.TouchEvent, itemId: string) => void;
   onTouchEnd: (e: React.TouchEvent) => void;
+  onContextMenu: (e: React.MouseEvent) => void;
 }
 
 export function ItemCard({
@@ -32,6 +32,7 @@ export function ItemCard({
   onDragEnd,
   onTouchStart,
   onTouchEnd,
+  onContextMenu,
 }: ItemCardProps) {
   return (
     <div
@@ -45,8 +46,9 @@ export function ItemCard({
       onDragEnd={onDragEnd}
       onTouchStart={(e) => onTouchStart(e, item.id)}
       onTouchEnd={onTouchEnd}
+      onContextMenu={onContextMenu}
       className={`
-        relative cursor-move bg-white rounded-lg shadow-md overflow-hidden transition-all duration-200
+        relative cursor-move bg-white rounded-lg shadow-md overflow-hidden transition-all duration-200 active:cursor-grabbing
         ${
           isDraggedItem && isDragging
             ? "opacity-80 scale-110 shadow-2xl ring-4 ring-blue-500 z-50 transform rotate-2"
@@ -68,6 +70,8 @@ export function ItemCard({
       `}
       style={{
         touchAction: isDragging ? "none" : "auto",
+        WebkitTouchCallout: "none",
+        userSelect: "none",
       }}
     >
       <img

--- a/app/components/items/ItemGalleryPreview.tsx
+++ b/app/components/items/ItemGalleryPreview.tsx
@@ -45,6 +45,10 @@ export function ItemGalleryPreview({
 
   const { handleAutoScroll, stopAutoScroll } = useAutoScroll();
 
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+  };
+
   if (isLoading) {
     return (
       <div className="flex justify-center py-8">
@@ -87,6 +91,7 @@ export function ItemGalleryPreview({
         onTouchEnd={handleTouchEnd}
         onAutoScroll={handleAutoScroll}
         onStopAutoScroll={stopAutoScroll}
+        onContextMenu={handleContextMenu}
       />
 
       {/* 操作説明 */}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "手ぬぐい帖",
   "short_name": "手ぬぐい帖",
   "description": "手ぬぐいコレクションを管理します",


### PR DESCRIPTION
設定画面でアイテムの並び順を変更するとき、アイテム画像を長押ししてもコンテキストメニューを表示しないように修正した。